### PR TITLE
Added .env file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 docs/_build/
 .coverage
 htmlcov
+.env


### PR DESCRIPTION
I'm experimenting with using .env to store some of the secrets. Even if nobody else ever does, it's good to have this file in your .gitignore for any pipenv projects, IMHO.