### PR TITLE
Add cache dir default name to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 docs/_build/
 .coverage
 htmlcov
+.court-scraper/


### PR DESCRIPTION
Someone, I won't say who, might try to stick this in their repo. We should help the poor fool out.